### PR TITLE
Soften warnings to messages on empty questions

### DIFF
--- a/R/read-data.R
+++ b/R/read-data.R
@@ -63,7 +63,7 @@ record_values <- function(data, site) {
 
 validate <- function(question, values) {
   question$value <- question$validator(values)
-  question <- signal_incomplete(question)
+  question <- check_incomplete(question)
   if (question$no == "OF29") {
     # Convert topo position character to numeric
     question$value <- topo_position(question$value)
@@ -72,11 +72,9 @@ validate <- function(question, values) {
   question
 }
 
-signal_incomplete <- function(q) {
+check_incomplete <- function(q) {
   if (isTRUE(attr(q$value, "incomplete"))) {
     q$incomplete <- TRUE
-    warning("Question ", q$no, " does not appear to have been filled out.",
-            call. = FALSE)
   }
   q
 }

--- a/R/test-helpers.R
+++ b/R/test-helpers.R
@@ -1,4 +1,8 @@
-make_test_site <- function(site = NULL) {
+make_test_site <- function(site = NULL, quiet = TRUE) {
   data <- load_wesp_data(testthat::test_path("test-wetflat.csv"))
-  suppressWarnings(as.wesp_site(data, site = site))
+
+  f <- if (quiet) suppressMessages else identity
+  f(
+    as.wesp_site(data, site = site)
+  )
 }

--- a/R/wesp-site-methods.R
+++ b/R/wesp-site-methods.R
@@ -23,7 +23,8 @@ print_incomplete_questions_helper <- function(x) {
 
   if (any(incomplete_q)) {
     incomplete <- names(x)[incomplete_q]
-    cat("Incomplete Questions: ", paste(incomplete, collapse = ", "), "\n\n")
+    cat("Incomplete Questions: ", paste(incomplete, collapse = ", "), "\n")
+    cat("  * Please ensure that it is valid to leave these questions unanswered.\n\n")
   }
 }
 

--- a/R/wesp_site-class.R
+++ b/R/wesp_site-class.R
@@ -35,6 +35,13 @@ as.wesp_site <- function(data, site = NULL) {
     derived_values = derived_values,
     indicators = indicators()
   )
+
+  incomplete_questions <- Filter(\(x) isTRUE(x$incomplete), site$questions)
+  if (length(incomplete_questions) > 0) {
+    message("Questions ", paste(names(incomplete_questions), collapse = ", "),
+            " do not appear to have been filled out.\n Please ensure this is valid.")
+  }
+
   class(site) <- "wesp_site"
   site
 }

--- a/tests/testthat/_snaps/setup.md
+++ b/tests/testthat/_snaps/setup.md
@@ -2,17 +2,7 @@
 
     Code
       site <- as.wesp_site(data)
-    Condition
-      Warning:
-      Question F25 does not appear to have been filled out.
-      Warning:
-      Question F41 does not appear to have been filled out.
-      Warning:
-      Question F43 does not appear to have been filled out.
-      Warning:
-      Question F44 does not appear to have been filled out.
-      Warning:
-      Question F59 does not appear to have been filled out.
-      Warning:
-      Question OF28 does not appear to have been filled out.
+    Message
+      Questions F25, F41, F43, F44, F59, OF28 do not appear to have been filled out.
+       Please ensure this is valid.
 

--- a/tests/testthat/_snaps/wesp-site-methods.md
+++ b/tests/testthat/_snaps/wesp-site-methods.md
@@ -8,6 +8,7 @@
       Site:  site_1 
       
       Incomplete Questions:  F25, F41, F43, F44, F59, OF28 
+        * Please ensure that it is valid to leave these questions unanswered.
       
       Derived values:
         *  AllWater = 0
@@ -65,6 +66,7 @@
       Site:  site_1 
       
       Incomplete Questions:  F25, F41, F43, F44, F59, OF28 
+        * Please ensure that it is valid to leave these questions unanswered.
       
       Derived values:
         *  AllWater = 0

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -14,13 +14,13 @@ test_that("site setup works", {
   data <- load_wesp_data(test_path("test-wetflat.csv"))
   expect_s3_class(data, "data.frame")
 
-  suppressWarnings(
+  suppressMessages(
     site2 <- as.wesp_site(data, site = "site_2")
   )
   expect_s3_class(site2, "wesp_site")
   expect_equal(site2$site_name, "site_2")
 
-  suppressWarnings(
+  suppressMessages(
     site3 <- as.wesp_site(data, site = 3)
   )
   expect_s3_class(site3, "wesp_site")


### PR DESCRIPTION
Closes #82.

For now, I have changed the multiple warnings to a single consolidated message and just have that message advise users to double check those questions. It seems less dire now I think. 

Actually validating them will require documenting all the cases where users are instructed to skip questions based on other questions, and then building that into the validation functionality. The validation functionality is currently question-by-question, so will take a bit of work to allow the validator functions to check other questions. I suggest pushing that down the road a bit, but can tackle it if you think it's worth it.